### PR TITLE
startDate

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ import Countdown from 'react-date-countdown';
 Attributes
 ----------
 
+- **startDate**: Delta of start date.
 - **finalDate**: Delta of final date.
 - **className** (optional): CSS class.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ import Countdown from 'react-date-countdown';
 Attributes
 ----------
 
-- **startDate**: Delta of start date.
+- **startDate**: Delta of start date. If this is set the component won't behave as a countdown but as an interval calculator between the start and final date
 - **finalDate**: Delta of final date.
 - **className** (optional): CSS class.

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import { PropTypes } from 'prop-types'
-import { start } from 'repl';
 
 export default class Countdown extends Component {
     constructor(props) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { PropTypes } from 'prop-types'
+import { start } from 'repl';
 
 export default class Countdown extends Component {
     constructor(props) {
@@ -13,18 +14,19 @@ export default class Countdown extends Component {
     }
 
     componentDidMount() {
-        const { finalDate } = this.props
+        const { startDate, finalDate } = this.props
 
-        this.getTime(finalDate)
+        this.getTime(startDate, finalDate)
     }
 
     addDigit(number) {
         return number >= 10 ? number : '0' + number
     }
 
-    getTime(finalDate) {
+    getTime(startDate, finalDate) {
         setInterval(() => {
-            const delta = (new Date(finalDate) - new Date())
+            const startDelta = startDate ? new Date(startDate) : new Date()
+            const delta = (new Date(finalDate) - startDelta)
             const seconds = delta / 1000
             const MINUTE = 60
             const HOUR = 60 * MINUTE
@@ -55,5 +57,6 @@ export default class Countdown extends Component {
 
 Countdown.propTypes = {
     finalDate: PropTypes.string.isRequired,
+    startDate: PropTypes.string,
     className: PropTypes.string
 }


### PR DESCRIPTION
It adds the enhancement suggested in the issue #2 

Now the user can define a startDate. If the startDate is set, the component will work as an interval calculator and will lose the countdown behaviour because the interval never changes.